### PR TITLE
Don't use lengths to make GenerateParams compatible with old R version

### DIFF
--- a/R/GenerateParams.r
+++ b/R/GenerateParams.r
@@ -47,7 +47,7 @@ GenerateParams = function (..., write = FALSE, splits = NULL,
 		nmc[ng0] <- nm[ng0]
 	names(cargs) <- nmc
 	rep.fac <- 1L
-	d <- lengths(args)
+	d <- unlist(lapply(args, FUN = length))
 
 	orep <- prod(d)
 	if (orep == 0L) {


### PR DESCRIPTION
Old R version on Grendel, so using the lenghts function is no go.